### PR TITLE
Add MacOS support

### DIFF
--- a/NodeHost/package.json
+++ b/NodeHost/package.json
@@ -9,6 +9,7 @@
     "precompile": "node scripts/precompile.js",
     "compile": "npx pkg -t node14-win . -o src/YTDPwin.exe",
     "postcompile": "node scripts/postcompile.js",
+    "compile:mac-arm64": "node scripts/precompile.js && npx pkg -t node18-macos-arm64 . -o src/YTDPmac-arm64 && bash scripts/postcompile_mac_arm64.sh",
     "postversion": "echo also update version in `background.js`, `manifest.json`, and when building!"
   },
   "author": "Michael Ren",

--- a/NodeHost/scripts/postcompile_mac_arm64.sh
+++ b/NodeHost/scripts/postcompile_mac_arm64.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Builds a macOS .pkg installer for YouTubeDiscordPresence (arm64).
+# Requires: macOS, Node.js, npm (for pkg), and Xcode Command Line Tools (pkgbuild).
+#
+# Usage (from inside NodeHost/):
+#   npm run build-installer:mac
+#
+# Output: src/YouTubeDiscordPresence-mac-arm64-<version>.pkg
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NODEHOST_DIR="$(dirname "$SCRIPT_DIR")"
+SRC_DIR="$NODEHOST_DIR/src"
+BINARY_SRC="$SRC_DIR/YTDPmac-arm64"
+
+# ── 1. Compile arm64 binary if not already built ─────────────────────────────
+if [ ! -f "$BINARY_SRC" ]; then
+    echo "Binary not found — compiling arm64 binary..."
+    cd "$NODEHOST_DIR"
+    node scripts/precompile.js
+    npx pkg -t node18-macos-arm64 . -o "$BINARY_SRC"
+    echo ""
+fi
+
+VERSION=$(node -e "console.log(require('$NODEHOST_DIR/package.json').version)")
+
+echo "YouTubeDiscordPresence — macOS .pkg builder"
+echo "============================================"
+echo "Version : $VERSION"
+echo "Binary  : $BINARY_SRC"
+echo ""
+
+# ── 2. Prepare staging directories ───────────────────────────────────────────
+BUILD_DIR="$NODEHOST_DIR/.build_mac"
+PAYLOAD_DIR="$BUILD_DIR/payload"
+SCRIPTS_DIR="$BUILD_DIR/scripts"
+
+# Fixed install paths (system-wide, requires admin — same as Windows MSI)
+INSTALL_RELATIVE="Library/Application Support/YouTubeDiscordPresence"
+INSTALL_ABS="/$INSTALL_RELATIVE"
+BINARY_DEST="$INSTALL_ABS/YTDPmac"
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$PAYLOAD_DIR/$INSTALL_RELATIVE"
+mkdir -p "$SCRIPTS_DIR"
+
+# ── 3. Stage binary ───────────────────────────────────────────────────────────
+cp "$BINARY_SRC" "$PAYLOAD_DIR/$INSTALL_RELATIVE/YTDPmac"
+chmod +x "$PAYLOAD_DIR/$INSTALL_RELATIVE/YTDPmac"
+
+# ── 4. Write postinstall script ───────────────────────────────────────────────
+# This runs as root after the pkg installs the files, registering the native
+# messaging host manifest for Chrome and any other detected Chromium browsers.
+cat > "$SCRIPTS_DIR/postinstall" << 'POSTINSTALL_EOF'
+#!/usr/bin/env bash
+set -e
+
+BINARY_PATH="/Library/Application Support/YouTubeDiscordPresence/YTDPmac"
+MANIFEST_NAME="com.ytdp.discord.presence.json"
+
+# Ensure the binary is executable and not quarantined
+chmod +x "$BINARY_PATH"
+xattr -d com.apple.quarantine "$BINARY_PATH" 2>/dev/null || true
+
+# Native messaging host manifest content (path is hardcoded to the install location)
+MANIFEST_CONTENT='{
+    "name": "com.ytdp.discord.presence",
+    "description": "Component of the YouTubeDiscordPresence extension that allows the usage of native messaging.",
+    "path": "/Library/Application Support/YouTubeDiscordPresence/YTDPmac",
+    "type": "stdio",
+    "allowed_origins": [
+        "chrome-extension://hnmeidgkfcbpjjjpmjmpehjdljlaeaaa/"
+    ]
+}'
+
+# System-wide manifest locations for each supported browser
+for NMH_DIR in \
+    "/Library/Google/Chrome/NativeMessagingHosts" \
+    "/Library/Application Support/Chromium/NativeMessagingHosts" \
+    "/Library/BraveSoftware/Brave-Browser/NativeMessagingHosts" \
+    "/Library/Microsoft/Edge/NativeMessagingHosts"
+do
+    mkdir -p "$NMH_DIR"
+    printf '%s\n' "$MANIFEST_CONTENT" > "$NMH_DIR/$MANIFEST_NAME"
+done
+
+exit 0
+POSTINSTALL_EOF
+
+chmod +x "$SCRIPTS_DIR/postinstall"
+
+# ── 5. Build the .pkg ─────────────────────────────────────────────────────────
+OUTPUT="$SRC_DIR/YouTubeDiscordPresence-mac-arm64-${VERSION}.pkg"
+
+pkgbuild \
+    --root "$PAYLOAD_DIR" \
+    --scripts "$SCRIPTS_DIR" \
+    --identifier "com.ytdp.discord.presence" \
+    --version "$VERSION" \
+    --install-location "/" \
+    "$OUTPUT"
+
+# ── 6. Clean up staging area ──────────────────────────────────────────────────
+rm -rf "$BUILD_DIR"
+
+echo ""
+echo "Installer created:"
+echo "  $OUTPUT"
+echo ""
+echo "Users double-click the .pkg and follow the macOS installer wizard."
+echo "Chrome/Brave/Edge/Chromium native messaging hosts are registered system-wide."
+echo ""
+echo "Note: the binary is unsigned. If Gatekeeper blocks the pkg, right-click it"
+echo "and choose Open, or run: sudo spctl --master-disable (re-enable after install)."

--- a/README.md
+++ b/README.md
@@ -10,12 +10,10 @@
 If you've already downloaded the extension, **skip the first step!**
 
 1. Add the [<ins>**Chrome Extension**</ins>](https://chrome.google.com/webstore/detail/youtubediscordpresence/hnmeidgkfcbpjjjpmjmpehjdljlaeaaa) from the Chrome Web Store.
-
    - To access personalization settings, click on the extension icon in your browser's extension menu at the top right corner of your browser.
 
 2. Download the latest `YTDPsetup.msi` file in the [**<ins>releases</ins>**](https://github.com/XFG16/YouTubeDiscordPresence/releases) section of this repository and **run it on your device** to install the secondary desktop component.
-
-   - **Note:** Only Windows (x64) is currently supported.
+   - **Note:** Only Windows (x64) and MacOS (arm64) are currently supported.
 
 Still confused? Watch the **installation tutorial** on YouTube using [**<ins>this link</ins>**](https://www.youtube.com/watch?v=BWPNqPGFyL4).
 
@@ -51,11 +49,9 @@ Still confused? Watch the **installation tutorial** on YouTube using [**<ins>thi
 If none of the above address your issue, then you should first disable and re-enable the extension. Then close and reopen your browser, especially...
 
 - If the extension is **not appearing** even after you installed the desktop application...
-
   - In this case, your Discord client is likely ratelimiting YTDP. To fix this, do not simply just reload Discord. Go to your system tray or task manager and quit Discord before relaunching it.
 
 - If **two or more instances of the rich presence** appear on your profile...
-
   - This is an error with the socket implementation Discord currently has and there is currently no easy way around it.
 
 ---
@@ -63,25 +59,20 @@ If none of the above address your issue, then you should first disable and re-en
 ## Bugs & Feature Requests
 
 ### Reporting a Bug
+
 Before submitting a new [Issue](https://github.com/XFG16/YouTubeDiscordPresence/issues/new), please follow these steps to help us debug:
 
 1.  **Search First:** Check if the issue has [already been reported](https://github.com/XFG16/YouTubeDiscordPresence/issues).
 2.  **Provide Details:**  
-In your issue description, include:
-    - Your browser (e.g., Chrome, Brave, Edge).
-    - The extension version.
-    - Pictures.
-    - What the service worker console log shows (especially errors, search 'error').
-        - Go to `chrome://extensions` in your browser.
-        - Turn on **Developer mode** (top right).
-        - Find `YouTubeDiscordPresence` and click **inspect views: <ins>service worker</ins>**.
-        - In the window that opens, go to the **Console** tab.
+    In your issue description, include: - Your browser (e.g., Chrome, Brave, Edge). - The extension version. - Pictures. - What the service worker console log shows (especially errors, search 'error'). - Go to `chrome://extensions` in your browser. - Turn on **Developer mode** (top right). - Find `YouTubeDiscordPresence` and click **inspect views: <ins>service worker</ins>**. - In the window that opens, go to the **Console** tab.
 
 > [!IMPORTANT]
 > Most connection issues can be fixed by fully quitting Discord (from the system tray) and restarting it, or by restarting your browser.
 
 ### Requesting a Feature
+
 If you have suggestions for new features:
+
 1.  Check if it's already [been suggested](https://github.com/XFG16/YouTubeDiscordPresence/issues).
 2.  Submit a new [Issue](https://github.com/XFG16/YouTubeDiscordPresence/issues/new) and describe your idea in detail!
 
@@ -89,16 +80,24 @@ If you have suggestions for new features:
 
 ## Building
 
-Desktop application:
-   - `npm run compile`
-   - Replace the existing `YTDPwin.exe` in `C:\Program Files\YouTubeDiscordPresence` with the newly compiled one.
+Desktop application (Windows):
 
-   - Building the `.msi`: Download **Visual Studio 2026** with the **Microsoft Visual Studio Installer Project** extension. Open `Host\YTDPwin\YTDPsetup\YTDPsetup.vdproj` and build `YTDPsetup`.
+- `npm run compile`
+- Replace the existing `YTDPwin.exe` in `C:\Program Files\YouTubeDiscordPresence` with the newly compiled one.
+
+- Building the `.msi`: Download **Visual Studio 2026** with the **Microsoft Visual Studio Installer Project** extension. Open `Host\YTDPwin\YTDPsetup\YTDPsetup.vdproj` and build `YTDPsetup`.
+
+Desktop application (macOS, Apple Silicon):
+
+- `npm run compile:mac-arm64`
+- Double click the file created at `src/YouTubeDiscordPresence-mac-arm64.pkg` and follow the installer wizard.
+- The installer places the binary at `/Library/Application Support/YouTubeDiscordPresence/YTDPmac` and registers the native messaging host.
 
 Extension:
-   - Download the `Extension` directory, compress it into a zip, and load it onto your browser manually.
 
-   - Make sure that the `"allowed_origins"` key in the JSON file involved in [**<ins>native messaging</ins>**](https://developer.chrome.com/docs/apps/nativeMessaging/) contains the extension's ID. This file should be found at `C:\Program Files\YouTubeDiscordPresence` as `main.json`.
+- Download the `Extension` directory, compress it into a zip, and load it onto your browser manually.
+
+- Make sure that the `"allowed_origins"` key in the JSON file involved in [**<ins>native messaging</ins>**](https://developer.chrome.com/docs/apps/nativeMessaging/) contains the extension's ID. This file should be found at `C:\Program Files\YouTubeDiscordPresence` as `main.json`.
 
 ---
 


### PR DESCRIPTION
Remaking PR as the old one was mistakenly closed. Original PR: https://github.com/XFG16/YouTubeDiscordPresence/pull/64

Original message --
This commit is a pretty simple one, which adds support to MacOS Arm64. It was tested on macOS Tahoe, version 26.4.1, and worked flawlessly. There are changes in 3 files total:

- Add postcompile_mac_arm64.sh which builds a .pkg installer.
- Update package.json with a new compile:mac-arm64 command, which creates the final .pkg installer using the postcompile script.
- Update README.md to mention MacOS support.

See video in original PR.