### PR TITLE
YouTube Music album names (via scraping)

### DIFF
--- a/Extension/background.js
+++ b/Extension/background.js
@@ -315,6 +315,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             currentMessage.scriptId = sender.tab.id;
             currentMessage.title = message.title;
             currentMessage.author = message.author;
+            currentMessage.album = message.album;
             currentMessage.timeLeft = message.timeLeft;
             currentMessage.duration = message.duration;
             currentMessage.videoId = message.videoId;
@@ -360,10 +361,11 @@ function generatePresenceData() {
 
     // large_text and details must be >1 char long, pad with zws
     let paddedTitle = currentMessage.title.padEnd(2, '\u200b');
+    let largeHoverText = (currentMessage.album ? currentMessage.album.padEnd(2, '\u200b') : paddedTitle).substring(0, 128);
 
     let assetsData = {
         large_image: "youtube3",
-        large_text: paddedTitle.substring(0, 128)
+        large_text: largeHoverText
     };
     if (currentMessage.applicationType == "youtubeMusic") {
         activityType = 2; // Activity: Listening
@@ -450,6 +452,7 @@ function updateCallback() {
         cppData: NMF.TITLE + currentMessage.title + NMF.AUTHOR + currentMessage.author + NMF.TIME_LEFT + Math.round(currentMessage.timeLeft) + NMF.END,
         jsTitle: currentMessage.title,
         jsAuthor: currentMessage.author,
+        jsAlbum: currentMessage.album,
         jsTimeLeft: currentMessage.timeLeft,
         jsVideoUrl: currentMessage.videoUrl,
         jsChannelUrl: currentMessage.channelUrl,
@@ -488,7 +491,7 @@ let pipeInterval = setInterval(function () {
     if (previousMessage.timeLeft >= currentMessage.timeLeft && ((1000 * (previousMessage.timeLeft - currentMessage.timeLeft) < 2 * NORMAL_MESSAGE_DELAY) || (previousMessage.timeLeft == LIVESTREAM_TIME_ID && currentMessage.timeLeft != LIVESTREAM_TIME_ID))) {
         skipMessage = true;
     }
-    if (!(previousMessage.title == currentMessage.title && previousMessage.author == currentMessage.author && previousMessage.thumbnailUrl == currentMessage.thumbnailUrl && skipMessage)) {
+    if (!(previousMessage.title == currentMessage.title && previousMessage.author == currentMessage.author && previousMessage.album == currentMessage.album && previousMessage.thumbnailUrl == currentMessage.thumbnailUrl && skipMessage)) {
         if (nativeVersionStatus < 0) {
             function getNativeVersion() {
                 sendNativeMessage({ getNativeVersion: true });
@@ -500,6 +503,7 @@ let pipeInterval = setInterval(function () {
 
     previousMessage.title = currentMessage.title;
     previousMessage.author = currentMessage.author;
+    previousMessage.album = currentMessage.album;
     previousMessage.timeLeft = currentMessage.timeLeft;
     previousMessage.thumbnailUrl = currentMessage.thumbnailUrl;
     isIdle = false;

--- a/Extension/content.js
+++ b/Extension/content.js
@@ -122,12 +122,31 @@ function sendDocumentData() {
     }
 }
 
+// EXTRACT ALBUM FROM YOUTUBE MUSIC DOM
+
+function extractAlbumFromDOM() {
+    if (!window.location.href.includes("music.youtube")) return null;
+    const byline =
+        document.querySelector('yt-formatted-string.byline.ytmusic-player-bar') ||
+        document.querySelector('.subtitle.ytmusic-player-bar yt-formatted-string.byline') ||
+        document.querySelector('ytmusic-player-bar .byline');
+
+    if (!byline) return null;
+
+    const links = byline.querySelectorAll('a');
+
+    return links.length >= 2
+        ? (links[links.length - 1].textContent?.trim() || null)
+        : null;
+}
+
 // SEPARATE FUNCTION FOR LIVESTREAM DATA OR MINIPLAYERS THAT INCLUDE THE AUTHOR
 
 function handleYouTubeData() {
     let livestreamHTML = videoPlayer.querySelector(LIVESTREAM_ELEMENT_SELECTOR);
     documentData.videoId = getVideoId(videoPlayer.getVideoUrl());
     documentData.applicationType = window.location.href.includes("music.youtube") ? "youtubeMusic" : "youtube";
+    documentData.album = extractAlbumFromDOM();
 
     documentData.thumbnailUrl = `https://i.ytimg.com/vi/${documentData.videoId}/mqdefault.jpg`;
 

--- a/Extension/content_loader.js
+++ b/Extension/content_loader.js
@@ -17,6 +17,7 @@ window.addEventListener("SendToLoader", function (message) {
         messageType: UPDATE_PRESENCE_MESSAGE,
         title: message.detail.title,
         author: message.detail.author,
+        album: message.detail.album,
         timeLeft: message.detail.timeLeft,
         duration: message.detail.duration,
         videoId: message.detail.videoId,


### PR DESCRIPTION
I thought it would be nice if the album name is included. Scraping is fragile but I saw [Better Lyrics](https://github.com/better-lyrics/better-lyrics) making pretty big modifications to the DOM itself while also scraping the album name to query animated artworks and I think it's neat if it's integrated here (if it ever breaks, it falls back to the original behavior).

<img width="286" height="133" alt="image" src="https://github.com/user-attachments/assets/672f57e9-e8e5-4ab9-9305-114396c50fb0" />
